### PR TITLE
More robust assembly base location

### DIFF
--- a/DirectXTexNet.Test/Tests.cs
+++ b/DirectXTexNet.Test/Tests.cs
@@ -398,7 +398,7 @@ namespace DirectXTexNet.Test
 
         private string GetOutputFolder()
         {
-            string outFolder = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "OutImages");
+            string outFolder = Path.Combine(Path.GetDirectoryName(AppContext.BaseDirectory), "OutImages");
             if (!Directory.Exists(outFolder))
             {
                 Directory.CreateDirectory(outFolder);
@@ -413,7 +413,7 @@ namespace DirectXTexNet.Test
             var dirToFind = Path.Combine(@"DirectXTexNet.Test", "Images");
 
             // Search up directory tree starting at assembly path looking for 'Images' dir.
-            var searchPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var searchPath = Path.GetDirectoryName(AppContext.BaseDirectory);
             while (true)
             {
                 var testPath = Path.Combine(searchPath, dirToFind);

--- a/DirectXTexNet/DirectXTexNet.cs
+++ b/DirectXTexNet/DirectXTexNet.cs
@@ -1160,7 +1160,7 @@ namespace DirectXTexNet
 
         static TexHelper()
         {
-            string folder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            string folder = Path.GetDirectoryName(AppContext.BaseDirectory);
             string fileName = "DirectXTexNetImpl.dll";
             string platform = Environment.Is64BitProcess ? "x64" : "x86";
 


### PR DESCRIPTION
The previous method could cause issues when, for example, using PathMap to override your build location to avoid doxxing yourself.